### PR TITLE
Added Pester tests for Set-DefaultPrinter

### DIFF
--- a/Windows/Set-DefaultPrinter.tests.ps1
+++ b/Windows/Set-DefaultPrinter.tests.ps1
@@ -1,0 +1,76 @@
+Describe 'Set-DefaultPrinter' {
+
+    BeforeAll {
+        . $PSScriptRoot\Set-DefaultPrinter.ps1
+    }
+
+    Context 'When no printer name is provided' {
+
+        It 'Should list installed printers' {
+
+            Mock Get-Printer {
+                return @(
+                    [PSCustomObject]@{ Name = "Printer1" }
+                    [PSCustomObject]@{ Name = "Printer2" }
+                )
+            }
+
+            Mock Write-Host {}
+
+            Set-DefaultPrinter
+
+            Assert-MockCalled Get-Printer
+            Assert-MockCalled Write-Host
+        }
+    }
+
+    Context 'When a valid printer name is provided' {
+
+        It 'Should set the default printer' {
+
+            Mock Get-Printer {
+                return @(
+                    [PSCustomObject]@{ Name = "Printer1" }
+                    [PSCustomObject]@{ Name = "Printer2" }
+                )
+            }
+
+            Mock Get-CimInstance {
+                $PrinterMock = [Microsoft.Management.Infrastructure.CimInstance]::new('Win32_Printer','root/cimv2')
+                $PrinterName = [Microsoft.Management.Infrastructure.CimProperty]::Create('Name','Printer1', [cimtype]::String, 'Property, ReadOnly')
+                $PrinterMock.CimInstanceProperties.Add($PrinterName)
+                
+                return $PrinterMock
+            }
+
+            Mock Invoke-CimMethod {
+                return $null
+            }
+
+            Set-DefaultPrinter -PrinterName "Printer1"
+
+            Assert-MockCalled Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Name='Printer1'" }
+
+            Assert-MockCalled Invoke-CimMethod -Exactly -Times 1 -Scope It -ParameterFilter { $MethodName -eq "SetDefaultPrinter" }
+        }
+    }
+
+    Context 'When an invalid printer name is provided' {
+
+        It 'Should throw an error' {
+
+            Mock Get-Printer {
+                return @(
+                    [PSCustomObject]@{ Name = "Printer1" }
+                    [PSCustomObject]@{ Name = "Printer2" }
+                )
+            }
+
+            Mock Get-CimInstance {
+                return $null
+            }
+
+            { Set-DefaultPrinter -PrinterName "InvalidPrinter" } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
I know this was just a bit of fun, but I had ChatGPT conceive some Pester tests for your `Set-DefaultPrinter` function. The tests it wrote didn't quite work, but I think i've fixed them up. It's actually a bit of a pain mocking `Get-CimInstance` but [this issue](https://github.com/pester/Pester/issues/1944) was really helpful.

Your function doesn't work on my machine for some reason. I'm running PowerShell 7.4.2 and `$script:PrinterNames` didn't seem to get set for me. To workaround it for the purposes of running the tests I replaced all uses of that with just a direct call to `(Get-Printer).Names` but I haven't committed those changes to your script as part of this PR as I assume its working for you.